### PR TITLE
feat: globals.css カラー定義（OKLCH + @theme inline）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,145 @@
 @import "tailwindcss";
+
+/* ============================================
+   カラートークン定義（OKLCH）
+   tailwind.config は編集しない。
+   色はすべてこのファイルで管理する。
+   ============================================ */
+
+:root {
+  /* Primary */
+  --primary: oklch(0.35 0.08 230);
+  --primary-foreground: oklch(0.98 0 0);
+
+  /* Secondary */
+  --secondary: oklch(0.93 0.02 260);
+  --secondary-foreground: oklch(0.2 0.02 260);
+
+  /* Background / Foreground */
+  --background: oklch(0.99 0 0);
+  --foreground: oklch(0.15 0.02 260);
+
+  /* Muted */
+  --muted: oklch(0.95 0.01 260);
+  --muted-foreground: oklch(0.5 0.02 260);
+
+  /* Card */
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.15 0.02 260);
+
+  /* Border / Input / Ring */
+  --border: oklch(0.88 0.01 260);
+  --input: oklch(0.88 0.01 260);
+  --ring: oklch(0.35 0.08 230);
+
+  /* Semantic */
+  --success: oklch(0.65 0.17 160);
+  --success-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.75 0.15 85);
+  --warning-foreground: oklch(0.2 0.05 85);
+  --danger: oklch(0.55 0.22 27);
+  --danger-foreground: oklch(0.98 0 0);
+
+  /* Accent */
+  --accent: oklch(0.93 0.02 260);
+  --accent-foreground: oklch(0.2 0.02 260);
+
+  /* Sidebar */
+  --sidebar: oklch(0.97 0.01 260);
+  --sidebar-foreground: oklch(0.15 0.02 260);
+  --sidebar-border: oklch(0.88 0.01 260);
+  --sidebar-accent: oklch(0.93 0.02 260);
+  --sidebar-accent-foreground: oklch(0.2 0.02 260);
+
+  --radius: 0.5rem;
+}
+
+.dark {
+  /* Primary */
+  --primary: oklch(0.55 0.1 230);
+  --primary-foreground: oklch(0.1 0 0);
+
+  /* Secondary */
+  --secondary: oklch(0.25 0.02 260);
+  --secondary-foreground: oklch(0.9 0.01 260);
+
+  /* Background / Foreground */
+  --background: oklch(0.13 0.02 260);
+  --foreground: oklch(0.93 0.01 260);
+
+  /* Muted */
+  --muted: oklch(0.2 0.02 260);
+  --muted-foreground: oklch(0.6 0.02 260);
+
+  /* Card */
+  --card: oklch(0.17 0.02 260);
+  --card-foreground: oklch(0.93 0.01 260);
+
+  /* Border / Input / Ring */
+  --border: oklch(0.3 0.02 260);
+  --input: oklch(0.3 0.02 260);
+  --ring: oklch(0.55 0.1 230);
+
+  /* Semantic */
+  --success: oklch(0.65 0.17 160);
+  --success-foreground: oklch(0.98 0 0);
+  --warning: oklch(0.75 0.15 85);
+  --warning-foreground: oklch(0.15 0.05 85);
+  --danger: oklch(0.55 0.22 27);
+  --danger-foreground: oklch(0.98 0 0);
+
+  /* Accent */
+  --accent: oklch(0.25 0.02 260);
+  --accent-foreground: oklch(0.9 0.01 260);
+
+  /* Sidebar */
+  --sidebar: oklch(0.15 0.02 260);
+  --sidebar-foreground: oklch(0.93 0.01 260);
+  --sidebar-border: oklch(0.3 0.02 260);
+  --sidebar-accent: oklch(0.25 0.02 260);
+  --sidebar-accent-foreground: oklch(0.9 0.01 260);
+}
+
+/* ============================================
+   Tailwind ユーティリティへの公開
+   bg-primary / text-foreground 等で使用可能
+   ============================================ */
+
+@theme inline {
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--danger-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --radius: var(--radius);
+}
+
+/* ============================================
+   ベースリセット
+   ============================================ */
+
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,39 @@
 const HomePage = () => {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background text-foreground">
       <h1 className="text-4xl font-bold">Devin Task Board</h1>
+
+      <div className="flex flex-wrap justify-center gap-4">
+        <button className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">
+          Primary
+        </button>
+        <button className="rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground">
+          Secondary
+        </button>
+        <button className="rounded-md bg-success px-4 py-2 text-sm font-medium text-success-foreground">
+          Success
+        </button>
+        <button className="rounded-md bg-warning px-4 py-2 text-sm font-medium text-warning-foreground">
+          Warning
+        </button>
+        <button className="rounded-md bg-danger px-4 py-2 text-sm font-medium text-danger-foreground">
+          Danger
+        </button>
+        <button className="rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-card-foreground">
+          Card
+        </button>
+        <button className="rounded-md bg-muted px-4 py-2 text-sm font-medium text-muted-foreground">
+          Muted
+        </button>
+        <button className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-foreground">
+          Accent
+        </button>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        html に <code className="rounded bg-muted px-1 py-0.5">.dark</code>{" "}
+        クラスを付与するとダークモードに切り替わります
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## 概要

Issue #2 の対応。`src/app/globals.css` に OKLCH カラートークンを定義し、`@theme inline` で Tailwind ユーティリティに公開。

## 変更内容

### globals.css
- **`:root`**: ライトモード用カラー変数（primary / secondary / background / foreground / muted / card / border / input / ring / success / warning / danger / accent / sidebar 系）
- **`.dark`**: ダークモード用カラー変数
- **`@theme inline`**: CSS 変数 → Tailwind ユーティリティクラス公開（`bg-primary`, `text-foreground` 等）
- **body**: ベースカラー適用

### page.tsx
- カラー確認用サンプルボタンを配置（Primary / Secondary / Success / Warning / Danger / Card / Muted / Accent）

## 確認方法

`npm run dev` → http://localhost:3000 でボタンの配色を確認。
DevTools で `<html>` に `class="dark"` を付与するとダークモードを確認可能。

## 確認事項

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] `tailwind.config` は未編集

closes #2