### PR TITLE
feat: Prisma 初期マイグレーション + seed データ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.8.0",
+        "bcryptjs": "^3.0.3",
         "next": "^16.2.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -16,6 +17,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@tailwindcss/postcss": "^4.1.4",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^22.14.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -2063,6 +2065,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2981,6 +2990,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,16 @@
     "db:generate": "prisma generate"
   },
   "dependencies": {
+    "@prisma/client": "^6.8.0",
+    "bcryptjs": "^3.0.3",
     "next": "^16.2.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@prisma/client": "^6.8.0"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@tailwindcss/postcss": "^4.1.4",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^22.14.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/prisma/migrations/20260417014905_init/migration.sql
+++ b/prisma/migrations/20260417014905_init/migration.sql
@@ -1,0 +1,235 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('ADMIN', 'MEMBER');
+
+-- CreateEnum
+CREATE TYPE "Theme" AS ENUM ('LIGHT', 'DARK', 'SYSTEM');
+
+-- CreateEnum
+CREATE TYPE "ProjectMemberRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER', 'VIEWER');
+
+-- CreateEnum
+CREATE TYPE "TaskStatus" AS ENUM ('BACKLOG', 'TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE');
+
+-- CreateEnum
+CREATE TYPE "TaskPriority" AS ENUM ('URGENT', 'HIGH', 'MEDIUM', 'LOW', 'NONE');
+
+-- CreateEnum
+CREATE TYPE "ActivityAction" AS ENUM ('CREATED', 'UPDATED', 'DELETED', 'STATUS_CHANGED', 'ASSIGNED', 'COMMENTED', 'ATTACHED');
+
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('TASK_ASSIGNED', 'TASK_COMMENTED', 'TASK_STATUS_CHANGED', 'TASK_DUE_SOON', 'MENTIONED');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "avatarUrl" TEXT,
+    "role" "UserRole" NOT NULL DEFAULT 'MEMBER',
+    "locale" TEXT NOT NULL DEFAULT 'ja',
+    "theme" "Theme" NOT NULL DEFAULT 'SYSTEM',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "key" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "project_members" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "ProjectMemberRole" NOT NULL DEFAULT 'MEMBER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tasks" (
+    "id" TEXT NOT NULL,
+    "taskNumber" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "TaskStatus" NOT NULL DEFAULT 'BACKLOG',
+    "priority" "TaskPriority" NOT NULL DEFAULT 'NONE',
+    "projectId" TEXT NOT NULL,
+    "assigneeId" TEXT,
+    "reporterId" TEXT NOT NULL,
+    "parentTaskId" TEXT,
+    "dueDate" TIMESTAMP(3),
+    "startDate" TIMESTAMP(3),
+    "estimatedHours" DOUBLE PRECISION,
+    "actualHours" DOUBLE PRECISION,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tasks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+
+    CONSTRAINT "categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "task_categories" (
+    "taskId" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+
+    CONSTRAINT "task_categories_pkey" PRIMARY KEY ("taskId","categoryId")
+);
+
+-- CreateTable
+CREATE TABLE "comments" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "attachments" (
+    "id" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "fileUrl" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "uploaderId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_logs" (
+    "id" TEXT NOT NULL,
+    "action" "ActivityAction" NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "oldValue" JSONB,
+    "newValue" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "userId" TEXT NOT NULL,
+    "linkUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "resource" TEXT NOT NULL,
+    "resourceId" TEXT NOT NULL,
+    "details" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_members_projectId_userId_key" ON "project_members"("projectId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tasks_projectId_taskNumber_key" ON "tasks"("projectId", "taskNumber");
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_members" ADD CONSTRAINT "project_members_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_members" ADD CONSTRAINT "project_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_parentTaskId_fkey" FOREIGN KEY ("parentTaskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "categories" ADD CONSTRAINT "categories_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "task_categories" ADD CONSTRAINT "task_categories_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "task_categories" ADD CONSTRAINT "task_categories_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "attachments" ADD CONSTRAINT "attachments_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "attachments" ADD CONSTRAINT "attachments_uploaderId_fkey" FOREIGN KEY ("uploaderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "audit_logs" ADD CONSTRAINT "audit_logs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,202 @@
+import { PrismaClient, TaskStatus, TaskPriority, ProjectMemberRole, UserRole } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+const main = async () => {
+  console.log("🌱 Seeding database...");
+
+  // ── Users ──────────────────────────────────────────
+  const passwordHash = await bcrypt.hash("password123", 10);
+
+  const admin = await prisma.user.upsert({
+    where: { email: "admin@example.com" },
+    update: {},
+    create: {
+      email: "admin@example.com",
+      name: "管理者 太郎",
+      password: passwordHash,
+      role: UserRole.ADMIN,
+    },
+  });
+
+  const member1 = await prisma.user.upsert({
+    where: { email: "member1@example.com" },
+    update: {},
+    create: {
+      email: "member1@example.com",
+      name: "開発者 花子",
+      password: passwordHash,
+      role: UserRole.MEMBER,
+    },
+  });
+
+  const member2 = await prisma.user.upsert({
+    where: { email: "member2@example.com" },
+    update: {},
+    create: {
+      email: "member2@example.com",
+      name: "開発者 次郎",
+      password: passwordHash,
+      role: UserRole.MEMBER,
+    },
+  });
+
+  console.log(`  ✓ Users: ${admin.name}, ${member1.name}, ${member2.name}`);
+
+  // ── Project ────────────────────────────────────────
+  const project = await prisma.project.upsert({
+    where: { id: "seed-project-1" },
+    update: {},
+    create: {
+      id: "seed-project-1",
+      name: "Devin Task Board",
+      description: "タスク管理アプリの開発プロジェクト",
+      key: "DTB",
+      ownerId: admin.id,
+    },
+  });
+
+  console.log(`  ✓ Project: ${project.name} (${project.key})`);
+
+  // ── Project Members ────────────────────────────────
+  const membersData = [
+    { projectId: project.id, userId: admin.id, role: ProjectMemberRole.OWNER },
+    { projectId: project.id, userId: member1.id, role: ProjectMemberRole.MEMBER },
+    { projectId: project.id, userId: member2.id, role: ProjectMemberRole.MEMBER },
+  ];
+
+  for (const m of membersData) {
+    await prisma.projectMember.upsert({
+      where: { projectId_userId: { projectId: m.projectId, userId: m.userId } },
+      update: {},
+      create: m,
+    });
+  }
+
+  console.log(`  ✓ Project Members: ${membersData.length} members`);
+
+  // ── Categories (F09 デフォルト) ────────────────────
+  const categoriesData = [
+    { name: "バグ", color: "oklch(0.55 0.22 27)", projectId: project.id },
+    { name: "機能追加", color: "oklch(0.55 0.1 230)", projectId: project.id },
+    { name: "改善", color: "oklch(0.65 0.17 160)", projectId: project.id },
+    { name: "ドキュメント", color: "oklch(0.55 0.15 300)", projectId: project.id },
+  ];
+
+  const categories = [];
+  for (const c of categoriesData) {
+    const cat = await prisma.category.upsert({
+      where: { id: `seed-cat-${c.name}` },
+      update: {},
+      create: { id: `seed-cat-${c.name}`, ...c },
+    });
+    categories.push(cat);
+  }
+
+  console.log(`  ✓ Categories: ${categories.map((c) => c.name).join(", ")}`);
+
+  // ── Tasks ──────────────────────────────────────────
+  const tasksData = [
+    {
+      taskNumber: 1,
+      title: "プロジェクト初期設定",
+      description: "## 概要\n\nDocker Compose + Next.js + PostgreSQL の環境構築",
+      status: TaskStatus.DONE,
+      priority: TaskPriority.HIGH,
+      projectId: project.id,
+      reporterId: admin.id,
+      assigneeId: admin.id,
+      sortOrder: 0,
+    },
+    {
+      taskNumber: 2,
+      title: "ログイン画面の実装",
+      description: "## 概要\n\nAuth.js v5 の Credentials Provider を使ったログイン画面",
+      status: TaskStatus.IN_PROGRESS,
+      priority: TaskPriority.HIGH,
+      projectId: project.id,
+      reporterId: admin.id,
+      assigneeId: member1.id,
+      sortOrder: 0,
+    },
+    {
+      taskNumber: 3,
+      title: "カンバンボード基本表示",
+      description: "## 概要\n\n5カラム（BACKLOG / TODO / IN_PROGRESS / IN_REVIEW / DONE）のカンバン表示",
+      status: TaskStatus.TODO,
+      priority: TaskPriority.MEDIUM,
+      projectId: project.id,
+      reporterId: admin.id,
+      assigneeId: member2.id,
+      sortOrder: 0,
+    },
+    {
+      taskNumber: 4,
+      title: "タスク詳細画面",
+      description: "## 概要\n\nタスクの全フィールドを表示・編集できる詳細画面",
+      status: TaskStatus.BACKLOG,
+      priority: TaskPriority.MEDIUM,
+      projectId: project.id,
+      reporterId: member1.id,
+      assigneeId: null,
+      sortOrder: 0,
+    },
+    {
+      taskNumber: 5,
+      title: "README の整備",
+      description: "## 概要\n\nセットアップ手順・スクリプト一覧を追記",
+      status: TaskStatus.DONE,
+      priority: TaskPriority.LOW,
+      projectId: project.id,
+      reporterId: admin.id,
+      assigneeId: member2.id,
+      sortOrder: 1,
+    },
+  ];
+
+  for (const t of tasksData) {
+    await prisma.task.upsert({
+      where: { projectId_taskNumber: { projectId: t.projectId, taskNumber: t.taskNumber } },
+      update: {},
+      create: t,
+    });
+  }
+
+  console.log(`  ✓ Tasks: ${tasksData.length} tasks`);
+
+  // ── TaskCategory (一部タスクにカテゴリを付与) ─────
+  const taskCategoryPairs = [
+    { taskNumber: 1, categoryName: "改善" },
+    { taskNumber: 2, categoryName: "機能追加" },
+    { taskNumber: 3, categoryName: "機能追加" },
+    { taskNumber: 5, categoryName: "ドキュメント" },
+  ];
+
+  for (const pair of taskCategoryPairs) {
+    const task = await prisma.task.findUnique({
+      where: { projectId_taskNumber: { projectId: project.id, taskNumber: pair.taskNumber } },
+    });
+    const category = categories.find((c) => c.name === pair.categoryName);
+    if (task && category) {
+      await prisma.taskCategory.upsert({
+        where: { taskId_categoryId: { taskId: task.id, categoryId: category.id } },
+        update: {},
+        create: { taskId: task.id, categoryId: category.id },
+      });
+    }
+  }
+
+  console.log(`  ✓ Task Categories: ${taskCategoryPairs.length} associations`);
+
+  console.log("✅ Seed completed!");
+};
+
+main()
+  .catch((e) => {
+    console.error("❌ Seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## 概要

Issue #3 の対応。初期マイグレーション作成と開発用 seed データの整備。

## 変更内容

### prisma/migrations/`init`
- 全11テーブル + 7 Enum のマイグレーション SQL

### prisma/seed.ts
| データ | 内容 |
|--------|------|
| Users | ADMIN 1名（admin@example.com）、MEMBER 2名 |
| Project | DTB（Devin Task Board） |
| Members | OWNER + MEMBER x2 |
| Categories | バグ(赤) / 機能追加(青) / 改善(緑) / ドキュメント(紫) |
| Tasks | 5件（DONE / IN_PROGRESS / TODO / BACKLOG に分散） |
| TaskCategory | 4件の紐付け |

- 全パスワード: `password123`（bcryptjs ハッシュ）
- `upsert` で冪等実行可能

### package.json
- `bcryptjs` + `@types/bcryptjs` 追加

## 確認コマンド

```bash
docker compose up db -d
npx prisma migrate dev
npx prisma db seed
npx prisma studio  # ブラウザで確認
```

## 確認事項

- [x] `npx prisma migrate dev` 成功
- [x] `npx prisma db seed` 成功
- [x] `npm run lint` パス
- [x] `npm run build` パス

closes #3