### PR TITLE
feat: Auth.js v5 + 認証画面（ログイン / サインアップ / proxy.ts）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,11 @@
         "@prisma/client": "^6.8.0",
         "bcryptjs": "^3.0.3",
         "next": "^16.2.4",
+        "next-auth": "^5.0.0-beta.31",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "sonner": "^2.0.7",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -41,6 +44,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1673,6 +1705,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@prisma/client": {
@@ -5202,6 +5243,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5804,6 +5854,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5889,6 +5966,15 @@
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6210,6 +6296,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -6759,6 +6864,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {
@@ -7503,7 +7618,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
     "@prisma/client": "^6.8.0",
     "bcryptjs": "^3.0.3",
     "next": "^16.2.4",
+    "next-auth": "^5.0.0-beta.31",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "sonner": "^2.0.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,10 @@
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-8 shadow-sm">
+        {children}
+      </div>
+    </div>
+  );
+};
+export default AuthLayout;

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+
+import { login } from "@/lib/actions/auth";
+
+import type { AuthState } from "@/lib/actions/auth";
+
+const LoginPage = () => {
+  const [state, formAction, isPending] = useActionState<AuthState, FormData>(login, null);
+
+  return (
+    <>
+      <div className="mb-6 text-center">
+        <h1 className="text-2xl font-bold text-foreground">ログイン</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          メールアドレスとパスワードでログイン
+        </p>
+      </div>
+
+      <form action={formAction} className="space-y-4">
+        {state?.error && (
+          <div className="rounded-md bg-danger/10 p-3 text-sm text-danger">
+            {state.error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="email" className="mb-1 block text-sm font-medium text-foreground">
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="you@example.com"
+          />
+          {state?.fieldErrors?.email && (
+            <p className="mt-1 text-xs text-danger">{state.fieldErrors.email[0]}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="password" className="mb-1 block text-sm font-medium text-foreground">
+            パスワード
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="••••••••"
+          />
+          {state?.fieldErrors?.password && (
+            <p className="mt-1 text-xs text-danger">{state.fieldErrors.password[0]}</p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {isPending ? "ログイン中..." : "ログイン"}
+        </button>
+      </form>
+
+      <p className="mt-4 text-center text-sm text-muted-foreground">
+        アカウントをお持ちでない方は{" "}
+        <Link href="/signup" className="font-medium text-primary hover:underline">
+          サインアップ
+        </Link>
+      </p>
+    </>
+  );
+};
+export default LoginPage;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+
+import { signup } from "@/lib/actions/auth";
+
+import type { AuthState } from "@/lib/actions/auth";
+
+const SignupPage = () => {
+  const [state, formAction, isPending] = useActionState<AuthState, FormData>(signup, null);
+
+  return (
+    <>
+      <div className="mb-6 text-center">
+        <h1 className="text-2xl font-bold text-foreground">サインアップ</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          新しいアカウントを作成
+        </p>
+      </div>
+
+      <form action={formAction} className="space-y-4">
+        {state?.error && (
+          <div className="rounded-md bg-danger/10 p-3 text-sm text-danger">
+            {state.error}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="name" className="mb-1 block text-sm font-medium text-foreground">
+            名前
+          </label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            required
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="山田 太郎"
+          />
+          {state?.fieldErrors?.name && (
+            <p className="mt-1 text-xs text-danger">{state.fieldErrors.name[0]}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="email" className="mb-1 block text-sm font-medium text-foreground">
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="you@example.com"
+          />
+          {state?.fieldErrors?.email && (
+            <p className="mt-1 text-xs text-danger">{state.fieldErrors.email[0]}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="password" className="mb-1 block text-sm font-medium text-foreground">
+            パスワード
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            minLength={8}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="8文字以上"
+          />
+          {state?.fieldErrors?.password && (
+            <p className="mt-1 text-xs text-danger">{state.fieldErrors.password[0]}</p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {isPending ? "作成中..." : "アカウントを作成"}
+        </button>
+      </form>
+
+      <p className="mt-4 text-center text-sm text-muted-foreground">
+        既にアカウントをお持ちの方は{" "}
+        <Link href="/login" className="font-medium text-primary hover:underline">
+          ログイン
+        </Link>
+      </p>
+    </>
+  );
+};
+export default SignupPage;

--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,0 +1,15 @@
+import { auth } from "@/lib/auth";
+
+const DashboardPage = async () => {
+  const session = await auth();
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background text-foreground">
+      <h1 className="text-3xl font-bold">ダッシュボード</h1>
+      <p className="text-muted-foreground">
+        ようこそ、{session?.user?.name ?? "ゲスト"} さん
+      </p>
+    </div>
+  );
+};
+export default DashboardPage;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,4 @@
+const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  return <>{children}</>;
+};
+export default MainLayout;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/lib/auth";
+
+export const { GET, POST } = handlers;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Toaster } from "sonner";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -10,7 +12,10 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Toaster richColors position="top-right" />
+      </body>
     </html>
   );
 };

--- a/src/app/proxy.ts
+++ b/src/app/proxy.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+
+import type { NextRequest } from "next/server";
+
+const protectedPaths = ["/dashboard", "/projects", "/notifications", "/settings", "/admin"];
+const authPaths = ["/login", "/signup"];
+
+export const proxy = async (request: NextRequest) => {
+  const session = await auth();
+  const { pathname } = request.nextUrl;
+
+  const isProtected = protectedPaths.some((path) => pathname.startsWith(path));
+  const isAuthPage = authPaths.some((path) => pathname.startsWith(path));
+
+  // 未認証で保護ページにアクセス → /login へリダイレクト
+  if (isProtected && !session) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("callbackUrl", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // 認証済みでログイン/サインアップページにアクセス → /dashboard へリダイレクト
+  if (isAuthPage && session) {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  return NextResponse.next();
+};
+
+export const config = {
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+  ],
+};
+
+export default proxy;

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import bcrypt from "bcryptjs";
+
+import { prisma } from "@/lib/prisma";
+import { signIn } from "@/lib/auth";
+import { signupSchema, loginSchema } from "@/lib/validations/auth";
+
+export type AuthState = {
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+} | null;
+
+export const signup = async (_prevState: AuthState, formData: FormData): Promise<AuthState> => {
+  const raw = {
+    name: formData.get("name"),
+    email: formData.get("email"),
+    password: formData.get("password"),
+  };
+
+  const parsed = signupSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { name, email, password } = parsed.data;
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return { error: "このメールアドレスは既に登録されています" };
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  await prisma.user.create({
+    data: {
+      name,
+      email,
+      password: hashedPassword,
+    },
+  });
+
+  try {
+    await signIn("credentials", {
+      email,
+      password,
+      redirectTo: "/dashboard",
+    });
+  } catch (error) {
+    // signIn throws NEXT_REDIRECT on success — rethrow it
+    if ((error as { digest?: string })?.digest?.startsWith("NEXT_REDIRECT")) {
+      throw error;
+    }
+    return { error: "アカウントは作成されましたが、自動ログインに失敗しました" };
+  }
+
+  return null;
+};
+
+export const login = async (_prevState: AuthState, formData: FormData): Promise<AuthState> => {
+  const raw = {
+    email: formData.get("email"),
+    password: formData.get("password"),
+  };
+
+  const parsed = loginSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  try {
+    await signIn("credentials", {
+      email: parsed.data.email,
+      password: parsed.data.password,
+      redirectTo: "/dashboard",
+    });
+  } catch (error) {
+    if ((error as { digest?: string })?.digest?.startsWith("NEXT_REDIRECT")) {
+      throw error;
+    }
+    return { error: "メールアドレスまたはパスワードが正しくありません" };
+  }
+
+  return null;
+};

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,64 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcryptjs";
+
+import { prisma } from "@/lib/prisma";
+
+import type { NextAuthConfig } from "next-auth";
+
+const authConfig: NextAuthConfig = {
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      authorize: async (credentials) => {
+        const email = credentials?.email as string | undefined;
+        const password = credentials?.password as string | undefined;
+
+        if (!email || !password) return null;
+
+        const user = await prisma.user.findUnique({
+          where: { email },
+        });
+
+        if (!user) return null;
+
+        const isValid = await bcrypt.compare(password, user.password);
+        if (!isValid) return null;
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        };
+      },
+    }),
+  ],
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    jwt: async ({ token, user }) => {
+      if (user) {
+        token.id = user.id;
+        token.role = (user as { role?: string }).role;
+      }
+      return token;
+    },
+    session: async ({ session, token }) => {
+      if (session.user) {
+        session.user.id = token.id as string;
+        (session.user as { role?: string }).role = token.role as string;
+      }
+      return session;
+    },
+  },
+  pages: {
+    signIn: "/login",
+  },
+};
+
+export const { handlers, signIn, signOut, auth } = NextAuth(authConfig);

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("有効なメールアドレスを入力してください"),
+  password: z.string().min(1, "パスワードを入力してください"),
+});
+
+export const signupSchema = z.object({
+  name: z.string().min(1, "名前を入力してください"),
+  email: z.string().email("有効なメールアドレスを入力してください"),
+  password: z.string().min(8, "パスワードは8文字以上で入力してください"),
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type SignupInput = z.infer<typeof signupSchema>;


### PR DESCRIPTION
## 概要

Issue #4 の対応。Auth.js v5 (next-auth@beta) + Credentials Provider による認証基盤を構築。

## 変更内容

### 認証基盤
- **`src/lib/auth.ts`**: Auth.js v5 設定（Credentials Provider / JWT セッション / Prisma ユーザー検証）
- **`src/app/api/auth/[...nextauth]/route.ts`**: Route Handler

### バリデーション / Server Actions
- **`src/lib/validations/auth.ts`**: zod スキーマ（login / signup）
- **`src/lib/actions/auth.ts`**: login / signup Server Actions
  - bcrypt パスワードハッシュ
  - 重複メールチェック
  - サインアップ後に自動ログイン → `/dashboard` リダイレクト

### 画面
- **`/login`**: useActionState + フォームバリデーション + エラー表示
- **`/signup`**: 名前・メール・パスワード（8文字以上）
- **`(auth)/layout.tsx`**: カード型の認証画面レイアウト
- **`/dashboard`**: プレースホルダ（セッションユーザー名表示）

### proxy.ts（認証ガード）
- `(main)` 配下（dashboard / projects / notifications / settings / admin）を保護
- 未認証 → `/login` へリダイレクト（callbackUrl 付き）
- 認証済みで `/login` / `/signup` アクセス → `/dashboard` へ

### その他
- `src/app/layout.tsx` に sonner `<Toaster />` 追加
- `next-auth@beta`, `zod`, `sonner` を依存追加

## 確認方法

```bash
docker compose up db -d
npx prisma migrate dev
npx prisma db seed
npm run dev
```

1. http://localhost:3000/login → seed ユーザー `admin@example.com` / `password123` でログイン
2. http://localhost:3000/signup → 新規アカウント作成
3. http://localhost:3000/dashboard → 認証済みのみアクセス可能

## 確認事項

- [x] `npm run lint` パス
- [x] `npm run build` パス

closes #4