### PR TITLE
feat: レイアウト（サイドバー + ヘッダー + ThemeProvider）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@prisma/client": "^6.8.0",
         "bcryptjs": "^3.0.3",
+        "lucide-react": "^1.8.0",
         "next": "^16.2.4",
         "next-auth": "^5.0.0-beta.31",
+        "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7",
@@ -5686,6 +5688,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5879,6 +5890,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@prisma/client": "^6.8.0",
     "bcryptjs": "^3.0.3",
+    "lucide-react": "^1.8.0",
     "next": "^16.2.4",
     "next-auth": "^5.0.0-beta.31",
+    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7",

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,19 @@
-const MainLayout = ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
+import { auth } from "@/lib/auth";
+import { Sidebar } from "@/components/layout/Sidebar";
+import { Header } from "@/components/layout/Header";
+
+const MainLayout = async ({ children }: { children: React.ReactNode }) => {
+  const session = await auth();
+  const userRole = (session?.user as { role?: string } | undefined)?.role;
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-background">
+      <Sidebar userRole={userRole} />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header userName={session?.user?.name} />
+        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      </div>
+    </div>
+  );
 };
 export default MainLayout;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { Toaster } from "sonner";
 
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -11,10 +13,12 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <body>
-        {children}
-        <Toaster richColors position="top-right" />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+          <Toaster richColors position="top-right" />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Bell, Search, Sun, Moon, LogOut, User } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+
+import { signOutAction } from "@/lib/actions/auth";
+
+export const Header = ({ userName }: { userName?: string | null }) => {
+  const { theme, setTheme } = useTheme();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4">
+      {/* 検索バー (placeholder) */}
+      <div className="relative max-w-md flex-1">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="タスクを検索..."
+          className="w-full rounded-md border border-input bg-background py-1.5 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          disabled
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* テーマ切替 */}
+        <button
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          className="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="テーマ切替"
+        >
+          {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+        </button>
+
+        {/* 通知ベル (placeholder) */}
+        <button
+          className="relative rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="通知"
+          disabled
+        >
+          <Bell size={18} />
+        </button>
+
+        {/* ユーザーメニュー */}
+        <div className="relative" ref={menuRef}>
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-muted"
+          >
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+              {userName?.[0]?.toUpperCase() ?? <User size={14} />}
+            </div>
+            <span className="hidden md:inline">{userName ?? "ユーザー"}</span>
+          </button>
+
+          {menuOpen && (
+            <div className="absolute right-0 top-full z-50 mt-1 w-48 rounded-md border border-border bg-card py-1 shadow-lg">
+              <form action={signOutAction}>
+                <button
+                  type="submit"
+                  className="flex w-full items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-muted"
+                >
+                  <LogOut size={16} />
+                  ログアウト
+                </button>
+              </form>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  FolderKanban,
+  Bell,
+  Settings,
+  ShieldCheck,
+} from "lucide-react";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+  adminOnly?: boolean;
+};
+
+const navItems: NavItem[] = [
+  { href: "/dashboard", label: "ダッシュボード", icon: <LayoutDashboard size={20} /> },
+  { href: "/projects", label: "プロジェクト", icon: <FolderKanban size={20} /> },
+  { href: "/notifications", label: "通知", icon: <Bell size={20} /> },
+  { href: "/settings", label: "設定", icon: <Settings size={20} /> },
+  { href: "/admin", label: "管理", icon: <ShieldCheck size={20} />, adminOnly: true },
+];
+
+export const Sidebar = ({ userRole }: { userRole?: string }) => {
+  const pathname = usePathname();
+
+  return (
+    <aside className="flex h-full w-60 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
+      <div className="flex h-14 items-center gap-2 border-b border-sidebar-border px-4">
+        <FolderKanban size={24} className="text-primary" />
+        <span className="text-lg font-bold">TaskBoard</span>
+      </div>
+
+      <nav className="flex-1 space-y-1 p-3">
+        {navItems
+          .filter((item) => !item.adminOnly || userRole === "ADMIN")
+          .map((item) => {
+            const isActive =
+              pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+                }`}
+              >
+                {item.icon}
+                {item.label}
+              </Link>
+            );
+          })}
+      </nav>
+    </aside>
+  );
+};

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+import type { ThemeProviderProps } from "next-themes";
+
+export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+};

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -3,7 +3,7 @@
 import bcrypt from "bcryptjs";
 
 import { prisma } from "@/lib/prisma";
-import { signIn } from "@/lib/auth";
+import { signIn, signOut } from "@/lib/auth";
 import { signupSchema, loginSchema } from "@/lib/validations/auth";
 
 export type AuthState = {
@@ -11,7 +11,10 @@ export type AuthState = {
   fieldErrors?: Record<string, string[]>;
 } | null;
 
-export const signup = async (_prevState: AuthState, formData: FormData): Promise<AuthState> => {
+export const signup = async (
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> => {
   const raw = {
     name: formData.get("name"),
     email: formData.get("email"),
@@ -51,13 +54,18 @@ export const signup = async (_prevState: AuthState, formData: FormData): Promise
     if ((error as { digest?: string })?.digest?.startsWith("NEXT_REDIRECT")) {
       throw error;
     }
-    return { error: "アカウントは作成されましたが、自動ログインに失敗しました" };
+    return {
+      error: "アカウントは作成されましたが、自動ログインに失敗しました",
+    };
   }
 
   return null;
 };
 
-export const login = async (_prevState: AuthState, formData: FormData): Promise<AuthState> => {
+export const login = async (
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> => {
   const raw = {
     email: formData.get("email"),
     password: formData.get("password"),
@@ -82,4 +90,8 @@ export const login = async (_prevState: AuthState, formData: FormData): Promise<
   }
 
   return null;
+};
+
+export const signOutAction = async () => {
+  await signOut({ redirectTo: "/login" });
 };


### PR DESCRIPTION
## 概要

Issue #5 の対応。認証後メイン画面のサイドバー + ヘッダー + ThemeProvider を実装。

## 変更内容

### 新規ファイル
| ファイル | 内容 |
|---------|------|
| `src/components/layout/Sidebar.tsx` | ナビリンク（ダッシュボード/プロジェクト/通知/設定/管理）、ADMIN 制御、アクティブハイライト |
| `src/components/layout/Header.tsx` | 検索バー(placeholder)、テーマ切替、通知ベル(placeholder)、ユーザーメニュー(ログアウト) |
| `src/components/providers/ThemeProvider.tsx` | next-themes ラッパー |

### 変更ファイル
- **`src/app/layout.tsx`**: `ThemeProvider`（`attribute="class"`, `defaultTheme="system"`）追加
- **`src/app/(main)/layout.tsx`**: Sidebar + Header + main の3領域レイアウト、セッションから userRole / userName 取得
- **`src/lib/actions/auth.ts`**: `signOutAction` 追加

### 依存追加
- `next-themes` — ダーク/ライト/システムテーマ切替
- `lucide-react` — アイコン

## 確認事項

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] アクティブリンクハイライト
- [x] ADMIN のみ「管理」リンク表示
- [x] ログアウト → `/login` へ遷移

closes #5