### PR TITLE
feat: タスク一覧 + 作成 + カンバン基本表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^6.8.0",
         "bcryptjs": "^3.0.3",
+        "date-fns": "^4.1.0",
         "lucide-react": "^1.8.0",
         "next": "^16.2.4",
         "next-auth": "^5.0.0-beta.31",
@@ -3392,6 +3393,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@prisma/client": "^6.8.0",
     "bcryptjs": "^3.0.3",
+    "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
     "next": "^16.2.4",
     "next-auth": "^5.0.0-beta.31",

--- a/src/app/(main)/projects/[id]/board/page.tsx
+++ b/src/app/(main)/projects/[id]/board/page.tsx
@@ -1,0 +1,57 @@
+import { notFound } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { KanbanBoard } from "@/components/board/KanbanBoard";
+import { CreateTaskDialog } from "@/components/tasks/CreateTaskDialog";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const BoardPage = async ({ params }: Props) => {
+  const { id: projectId } = await params;
+  const session = await auth();
+  if (!session?.user?.id) notFound();
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    include: {
+      members: {
+        include: { user: { select: { id: true, name: true } } },
+      },
+    },
+  });
+
+  if (!project) notFound();
+
+  const currentMember = project.members.find((m) => m.userId === session.user!.id);
+  if (!currentMember) notFound();
+
+  const tasks = await prisma.task.findMany({
+    where: { projectId },
+    include: {
+      assignee: { select: { name: true } },
+    },
+    orderBy: [{ sortOrder: "asc" }, { createdAt: "desc" }],
+  });
+
+  const canCreate = currentMember.role !== "VIEWER";
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">{project.name}</h1>
+          <p className="text-sm text-muted-foreground">カンバンボード</p>
+        </div>
+        {canCreate && (
+          <CreateTaskDialog projectId={projectId} members={project.members} />
+        )}
+      </div>
+
+      <KanbanBoard tasks={tasks} projectKey={project.key} />
+    </div>
+  );
+};
+export default BoardPage;

--- a/src/app/(main)/projects/page.tsx
+++ b/src/app/(main)/projects/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { FolderKanban } from "lucide-react";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+
+const ProjectsPage = async () => {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const memberships = await prisma.projectMember.findMany({
+    where: { userId: session.user.id },
+    include: {
+      project: {
+        include: {
+          _count: { select: { tasks: true, members: true } },
+        },
+      },
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold text-foreground">プロジェクト</h1>
+
+      {memberships.length === 0 ? (
+        <p className="text-muted-foreground">参加中のプロジェクトはありません</p>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {memberships.map(({ project }) => (
+            <Link
+              key={project.id}
+              href={`/projects/${project.id}/board`}
+              className="rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary/10 text-primary">
+                  <FolderKanban size={20} />
+                </div>
+                <div>
+                  <h2 className="font-semibold text-card-foreground">{project.name}</h2>
+                  <p className="text-xs text-muted-foreground">{project.key}</p>
+                </div>
+              </div>
+              <div className="mt-3 flex gap-4 text-xs text-muted-foreground">
+                <span>タスク {project._count.tasks}</span>
+                <span>メンバー {project._count.members}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+export default ProjectsPage;

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { createTaskSchema } from "@/lib/validations/task";
+
+import type { NextRequest } from "next/server";
+
+export const GET = async (
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+        { status: 401 },
+      );
+    }
+
+    const { id: projectId } = await params;
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+    if (!project) {
+      return NextResponse.json(
+        {
+          error: { code: "NOT_FOUND", message: "プロジェクトが見つかりません" },
+        },
+        { status: 404 },
+      );
+    }
+
+    const tasks = await prisma.task.findMany({
+      where: { projectId },
+      include: {
+        assignee: { select: { id: true, name: true } },
+        reporter: { select: { id: true, name: true } },
+        categories: { include: { category: true } },
+      },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "desc" }],
+    });
+
+    return NextResponse.json({ data: tasks });
+  } catch (error) {
+    console.error("[GET /api/projects/[id]/tasks]", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "サーバーエラーが発生しました",
+        },
+      },
+      { status: 500 },
+    );
+  }
+};
+
+export const POST = async (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+        { status: 401 },
+      );
+    }
+
+    const { id: projectId } = await params;
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+    if (!project) {
+      return NextResponse.json(
+        {
+          error: { code: "NOT_FOUND", message: "プロジェクトが見つかりません" },
+        },
+        { status: 404 },
+      );
+    }
+
+    // 権限チェック
+    const member = await prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId, userId: session.user.id } },
+    });
+    if (!member || member.role === "VIEWER") {
+      return NextResponse.json(
+        {
+          error: {
+            code: "FORBIDDEN",
+            message: "タスクを作成する権限がありません",
+          },
+        },
+        { status: 403 },
+      );
+    }
+
+    const body = await request.json();
+    const parsed = createTaskSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: parsed.error.issues[0].message,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    // 連番採番
+    const lastTask = await prisma.task.findFirst({
+      where: { projectId },
+      orderBy: { taskNumber: "desc" },
+      select: { taskNumber: true },
+    });
+    const nextNumber = (lastTask?.taskNumber ?? 0) + 1;
+
+    const task = await prisma.task.create({
+      data: {
+        title: parsed.data.title,
+        description: parsed.data.description,
+        status: parsed.data.status,
+        priority: parsed.data.priority,
+        assigneeId: parsed.data.assigneeId,
+        dueDate: parsed.data.dueDate ? new Date(parsed.data.dueDate) : null,
+        projectId,
+        reporterId: session.user.id,
+        taskNumber: nextNumber,
+      },
+    });
+
+    return NextResponse.json({ data: task }, { status: 201 });
+  } catch (error) {
+    console.error("[POST /api/projects/[id]/tasks]", error);
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "サーバーエラーが発生しました",
+        },
+      },
+      { status: 500 },
+    );
+  }
+};

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -1,0 +1,42 @@
+import { KanbanColumn } from "@/components/board/KanbanColumn";
+
+import type { TaskPriority, TaskStatus } from "@prisma/client";
+
+type Task = {
+  id: string;
+  taskNumber: number;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate: Date | null;
+  assignee: { name: string } | null;
+};
+
+type KanbanBoardProps = {
+  tasks: Task[];
+  projectKey: string;
+};
+
+const columns: { status: TaskStatus; label: string }[] = [
+  { status: "BACKLOG", label: "Backlog" },
+  { status: "TODO", label: "Todo" },
+  { status: "IN_PROGRESS", label: "In Progress" },
+  { status: "IN_REVIEW", label: "In Review" },
+  { status: "DONE", label: "Done" },
+];
+
+export const KanbanBoard = ({ tasks, projectKey }: KanbanBoardProps) => {
+  return (
+    <div className="flex gap-4 overflow-x-auto pb-4">
+      {columns.map((col) => (
+        <KanbanColumn
+          key={col.status}
+          status={col.status}
+          label={col.label}
+          tasks={tasks.filter((t) => t.status === col.status)}
+          projectKey={projectKey}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -1,0 +1,53 @@
+import { TaskCard } from "@/components/tasks/TaskCard";
+
+import type { TaskPriority, TaskStatus } from "@prisma/client";
+
+type Task = {
+  id: string;
+  taskNumber: number;
+  title: string;
+  priority: TaskPriority;
+  dueDate: Date | null;
+  assignee: { name: string } | null;
+};
+
+type KanbanColumnProps = {
+  status: TaskStatus;
+  label: string;
+  tasks: Task[];
+  projectKey: string;
+};
+
+export const KanbanColumn = ({
+  status,
+  label,
+  tasks,
+  projectKey,
+}: KanbanColumnProps) => {
+  return (
+    <div className="flex w-72 shrink-0 flex-col rounded-lg bg-muted/50">
+      <div className="flex items-center justify-between px-3 py-2">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-foreground">{label}</h3>
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            {tasks.length}
+          </span>
+        </div>
+      </div>
+
+      <div
+        className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2"
+        data-status={status}
+      >
+        {tasks.map((task) => (
+          <TaskCard key={task.id} task={task} projectKey={projectKey} />
+        ))}
+        {tasks.length === 0 && (
+          <p className="py-8 text-center text-xs text-muted-foreground">
+            タスクなし
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/tasks/CreateTaskDialog.tsx
+++ b/src/components/tasks/CreateTaskDialog.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+
+import { TaskForm } from "@/components/tasks/TaskForm";
+
+type Member = {
+  userId: string;
+  user: { id: string; name: string };
+};
+
+type CreateTaskDialogProps = {
+  projectId: string;
+  members: Member[];
+};
+
+export const CreateTaskDialog = ({ projectId, members }: CreateTaskDialogProps) => {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+      >
+        <Plus size={16} />
+        タスクを作成
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 shadow-lg">
+      <h3 className="mb-3 text-sm font-semibold text-foreground">新しいタスク</h3>
+      <TaskForm
+        projectId={projectId}
+        members={members}
+        onClose={() => setOpen(false)}
+      />
+    </div>
+  );
+};

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -1,0 +1,66 @@
+import { Calendar, User } from "lucide-react";
+import { format } from "date-fns";
+
+import type { TaskPriority } from "@prisma/client";
+
+type TaskCardProps = {
+  task: {
+    id: string;
+    taskNumber: number;
+    title: string;
+    priority: TaskPriority;
+    dueDate: Date | null;
+    assignee: { name: string } | null;
+  };
+  projectKey: string;
+};
+
+const priorityConfig: Record<TaskPriority, { label: string; className: string }> = {
+  URGENT: { label: "緊急", className: "bg-danger text-danger-foreground" },
+  HIGH: { label: "高", className: "bg-danger/70 text-danger-foreground" },
+  MEDIUM: { label: "中", className: "bg-warning text-warning-foreground" },
+  LOW: { label: "低", className: "bg-success text-success-foreground" },
+  NONE: { label: "なし", className: "bg-muted text-muted-foreground" },
+};
+
+export const TaskCard = ({ task, projectKey }: TaskCardProps) => {
+  const priority = priorityConfig[task.priority];
+
+  return (
+    <div className="rounded-md border border-border bg-card p-3 shadow-sm transition-shadow hover:shadow-md">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {projectKey}-{task.taskNumber}
+        </span>
+        <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${priority.className}`}>
+          {priority.label}
+        </span>
+      </div>
+
+      <p className="text-sm font-medium text-card-foreground">{task.title}</p>
+
+      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+        {task.dueDate ? (
+          <span className="flex items-center gap-1">
+            <Calendar size={12} />
+            {format(new Date(task.dueDate), "MM/dd")}
+          </span>
+        ) : (
+          <span />
+        )}
+
+        {task.assignee ? (
+          <span className="flex items-center gap-1">
+            <div className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] text-primary-foreground">
+              {task.assignee.name[0]}
+            </div>
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 text-muted-foreground/50">
+            <User size={12} />
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/tasks/TaskForm.tsx
+++ b/src/components/tasks/TaskForm.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useActionState, useRef, useEffect } from "react";
+
+import { createTask } from "@/lib/actions/task";
+
+import type { TaskFormState } from "@/lib/actions/task";
+
+type Member = {
+  userId: string;
+  user: { id: string; name: string };
+};
+
+type TaskFormProps = {
+  projectId: string;
+  members: Member[];
+  onClose?: () => void;
+};
+
+export const TaskForm = ({ projectId, members, onClose }: TaskFormProps) => {
+  const boundAction = createTask.bind(null, projectId);
+  const [state, formAction, isPending] = useActionState<TaskFormState, FormData>(boundAction, null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state?.success) {
+      formRef.current?.reset();
+      onClose?.();
+    }
+  }, [state?.success, onClose]);
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-3">
+      {state?.error && (
+        <div className="rounded-md bg-danger/10 p-2 text-sm text-danger">{state.error}</div>
+      )}
+
+      <div>
+        <input
+          name="title"
+          placeholder="タスクタイトル *"
+          required
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        {state?.fieldErrors?.title && (
+          <p className="mt-1 text-xs text-danger">{state.fieldErrors.title[0]}</p>
+        )}
+      </div>
+
+      <textarea
+        name="description"
+        placeholder="説明（Markdown 対応）"
+        rows={3}
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+      />
+
+      <div className="grid grid-cols-2 gap-2">
+        <select
+          name="status"
+          defaultValue="BACKLOG"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="BACKLOG">Backlog</option>
+          <option value="TODO">Todo</option>
+          <option value="IN_PROGRESS">In Progress</option>
+          <option value="IN_REVIEW">In Review</option>
+          <option value="DONE">Done</option>
+        </select>
+
+        <select
+          name="priority"
+          defaultValue="NONE"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="NONE">優先度なし</option>
+          <option value="LOW">低</option>
+          <option value="MEDIUM">中</option>
+          <option value="HIGH">高</option>
+          <option value="URGENT">緊急</option>
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <select
+          name="assigneeId"
+          defaultValue=""
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value="">担当者なし</option>
+          {members.map((m) => (
+            <option key={m.userId} value={m.userId}>
+              {m.user.name}
+            </option>
+          ))}
+        </select>
+
+        <input
+          name="dueDate"
+          type="date"
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
+          >
+            キャンセル
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {isPending ? "作成中..." : "タスクを作成"}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/lib/actions/task.ts
+++ b/src/lib/actions/task.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { createTaskSchema } from "@/lib/validations/task";
+
+export type TaskFormState = {
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+  success?: boolean;
+} | null;
+
+export const createTask = async (
+  projectId: string,
+  _prevState: TaskFormState,
+  formData: FormData,
+): Promise<TaskFormState> => {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { error: "認証が必要です" };
+  }
+
+  const raw = {
+    title: formData.get("title"),
+    description: formData.get("description") || undefined,
+    status: formData.get("status") || "BACKLOG",
+    priority: formData.get("priority") || "NONE",
+    assigneeId: formData.get("assigneeId") || null,
+    dueDate: formData.get("dueDate") || null,
+  };
+
+  const parsed = createTaskSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  // 連番採番
+  const lastTask = await prisma.task.findFirst({
+    where: { projectId },
+    orderBy: { taskNumber: "desc" },
+    select: { taskNumber: true },
+  });
+  const nextNumber = (lastTask?.taskNumber ?? 0) + 1;
+
+  await prisma.task.create({
+    data: {
+      title: parsed.data.title,
+      description: parsed.data.description,
+      status: parsed.data.status,
+      priority: parsed.data.priority,
+      assigneeId: parsed.data.assigneeId,
+      dueDate: parsed.data.dueDate ? new Date(parsed.data.dueDate) : null,
+      projectId,
+      reporterId: session.user.id,
+      taskNumber: nextNumber,
+    },
+  });
+
+  revalidatePath(`/projects/${projectId}/board`);
+  return { success: true };
+};

--- a/src/lib/validations/task.ts
+++ b/src/lib/validations/task.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1, "タイトルは必須です"),
+  description: z.string().optional(),
+  status: z.enum(["BACKLOG", "TODO", "IN_PROGRESS", "IN_REVIEW", "DONE"]).default("BACKLOG"),
+  priority: z.enum(["URGENT", "HIGH", "MEDIUM", "LOW", "NONE"]).default("NONE"),
+  assigneeId: z.string().optional().nullable(),
+  dueDate: z.string().optional().nullable(),
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;


### PR DESCRIPTION
## 概要

Issue #6 の対応。プロジェクト単位のタスク CRUD 最小版とカンバンボード基本表示。D&D は含まない。

## 変更内容

### ページ
| パス | 内容 |
|------|------|
| `/projects` | プロジェクト一覧（参加中プロジェクトのカード表示） |
| `/projects/[id]/board` | カンバンボード（5カラム: BACKLOG/TODO/IN_PROGRESS/IN_REVIEW/DONE） |

### コンポーネント
| ファイル | 内容 |
|---------|------|
| `KanbanBoard.tsx` | 5カラム横並びレイアウト |
| `KanbanColumn.tsx` | カラム（ステータスラベル + タスク数 + カードリスト） |
| `TaskCard.tsx` | タスク番号(DTB-1)・タイトル・優先度バッジ・担当者アバター・期限 |
| `TaskForm.tsx` | タスク作成フォーム（useActionState + zod） |
| `CreateTaskDialog.tsx` | フォーム表示切替ラッパー |

### Server Action / API
- **`createTask`**: 連番採番、reporterId 自動記録、revalidatePath
- **`GET /api/projects/[id]/tasks`**: タスク一覧（assignee/reporter/categories 含む）
- **`POST /api/projects/[id]/tasks`**: タスク作成（zod / 権限チェック / 統一エラーレスポンス）
- VIEWER ロール → 作成ボタン非表示 + API 403

### バリデーション
- `src/lib/validations/task.ts`: createTaskSchema（タイトル必須）

### 依存追加
- `date-fns` — 日付フォーマット

## 確認方法

```bash
docker compose up db -d
npx prisma migrate dev
npx prisma db seed
npm run dev
```

1. ログイン → `/projects` → 「Devin Task Board」クリック
2. カンバンボードに seed タスクが表示される
3. 「タスクを作成」でフォーム表示 → 各フィールド入力して作成

## 確認事項

- [x] `npm run lint` パス
- [x] `npm run build` パス

closes #6