### PR TITLE
fix: Codespaces で Server Actions の origin 不一致エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN npx prisma generate
 
 EXPOSE 3000
 
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "dev:setup"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.app.github.dev"],
+};
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["*.app.github.dev"],
+  experimental: {
+    serverActions: {
+      allowedOrigins: ["*.app.github.dev", "localhost:3000"],
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要

Codespaces 環境でログイン時に Server Actions が `x-forwarded-host` と `origin` の不一致で 500 エラーになる問題を修正。

## 原因

Codespaces のリバースプロキシ（`*.app.github.dev`）経由のリクエストで、Next.js が origin 検証に失敗していた。

## 修正内容

`next.config.ts` に `allowedDevOrigins: ["*.app.github.dev"]` を追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to allowlist specific development origins, enabling compatibility with designated development contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->